### PR TITLE
docs: add recruiter-friendly technology overview to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Click here to visit the website: https://sharebite-tawny.vercel.app
 
 Here is the link for a short Video of the project: [Video Link](https://drive.google.com/file/d/1S0VkYD2HxJOYI-xyqvVvU5PP79zRS8mF/view?usp=sharing)
 
-## ⚡ Quick Recruiter Snapshot
+## ⚡Quick Recruiter Snapshot
 
 ShareBite is a full-stack social-impact web platform that helps reduce food waste and hunger by connecting food donors, NGOs, and volunteers in one workflow.
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,25 @@ Click here to visit the website: https://sharebite-tawny.vercel.app
 
 Here is the link for a short Video of the project: [Video Link](https://drive.google.com/file/d/1S0VkYD2HxJOYI-xyqvVvU5PP79zRS8mF/view?usp=sharing)
 
+## ⚡ Quick Recruiter Snapshot
+
+ShareBite is a full-stack social-impact web platform that helps reduce food waste and hunger by connecting food donors, NGOs, and volunteers in one workflow.
+
+### Technologies Used (and Why)
+
+| Technology | Purpose in this Project | Skill Demonstrated |
+| --- | --- | --- |
+| React + TypeScript | Build the frontend UI with reusable, typed components | Frontend architecture, typed UI development |
+| Redux | Manage shared app state across roles and workflows | Predictable state management |
+| Node.js + Express.js | Create backend APIs and business logic for posts, delivery flow, and users | REST API development, backend design |
+| MongoDB | Store users, posts, and delivery-related data | NoSQL data modeling |
+| Firebase | Support cloud integration services used by the app | Cloud service integration |
+| Bootstrap + Sass + CSS | Build responsive, styled interfaces quickly | Responsive design, UI implementation |
+| Microsoft Azure Translation API | Provide multilingual support (150+ languages) | External API integration, accessibility |
+| LocationIQ + Google Geocoding APIs | Handle address/coordinate conversion for pickup and drop | Geo-enabled product workflows |
+| jsPDF | Generate donor certificates dynamically | Document generation in web apps |
+| PWA setup | Deliver app-like experience across devices | Progressive Web App development |
+
 # About ShareBite
 
 ShareBite is a collaborative platform that connects surplus food providers, volunteers, and individuals in need, creating a network where surplus food can be efficiently redistributed to those who require it the most. By harnessing the power of technology, we strive to eliminate food waste while simultaneously combating hunger in our communities.


### PR DESCRIPTION
### Motivation
- Help recruiters and first-time reviewers quickly understand what the project does and what skills the contributors demonstrated. 
- Provide a short, scannable tech-to-purpose mapping so readers can assess the stack and practical experience at a glance.

### Description
- Added a new `⚡ Quick Recruiter Snapshot` section near the top of `README.md` with a concise one-line project summary. 
- Added a `Technologies Used (and Why)` table that maps each core technology to its purpose in the project and the skill demonstrated. 
- Change is documentation-only and does not modify application code or behavior.

### Testing
- Inspected the applied diff using `git diff -- README.md` and confirmed the new section and table are present. 
- Checked repository status with `git status --short` to confirm the working tree state after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4bce615f8832e8af217a242099de8)